### PR TITLE
chore(workflow): update hugo version

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -31,7 +31,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.128.0
+      HUGO_VERSION: 0.146.4
     steps:
       - name: Install Hugo CLI
         run: |


### PR DESCRIPTION
avoid diagnosing a stale hugo version when builds fail